### PR TITLE
large enough range of unerased flash memory

### DIFF
--- a/FlashTxx.c
+++ b/FlashTxx.c
@@ -43,18 +43,35 @@ int firmware_buffer_init( uint32_t *buffer_addr, uint32_t *buffer_size )
   #endif
 
   // buffer will begin at first sector ABOVE code and below FLASH_RESERVE
-  // start at bottom of FLASH_RESERVE and work down until non-erased flash found
+  // start at bottom of FLASH_RESERVE and work down until large enough non-erased flash found
   *buffer_addr = FLASH_BASE_ADDR + FLASH_SIZE - FLASH_RESERVE - 4;
-  while (*buffer_addr > 0 && *((uint32_t *)*buffer_addr) == 0xFFFFFFFF)
-    *buffer_addr -= 4;
-  *buffer_addr += 4; // first address above code
+  uint32_t buffer_end = *buffer_addr;
+  do {
+    while (*buffer_addr > 0 && *((uint32_t *)*buffer_addr) == 0xFFFFFFFF)
+      *buffer_addr -= 4;
+    if (buffer_end - *buffer_addr > FLASH_SECTOR_SIZE) {
+      buffer_end += 4;   // address behind non-erased flash
+      *buffer_addr += 4; // first address above code
+      break;
+    }
+    else {
+      // skip non-erased flash memory:
+      while (*buffer_addr > 0 && *((uint32_t *)*buffer_addr) != 0xFFFFFFFF)
+	*buffer_addr -= 4;
+      buffer_end = *buffer_addr;
+    }
+  } while (*buffer_addr > 0);
 
   // increase buffer_addr to next sector boundary (if not on a sector boundary)
   if ((*buffer_addr % FLASH_SECTOR_SIZE) > 0)
     *buffer_addr += FLASH_SECTOR_SIZE - (*buffer_addr % FLASH_SECTOR_SIZE);
-  *buffer_size = FLASH_BASE_ADDR - *buffer_addr + FLASH_SIZE - FLASH_RESERVE;
-
-  return( FLASH_BUFFER_TYPE );
+  // decrease buffer_end to previous sector boundary:
+  buffer_end = (buffer_end/FLASH_SECTOR_SIZE)*FLASH_SECTOR_SIZE;
+  *buffer_size = buffer_end - *buffer_addr;
+  if (*buffer_size >= FLASH_SECTOR_SIZE)
+    return( FLASH_BUFFER_TYPE );
+  
+  return( NO_BUFFER_TYPE );
 }
 
 //******************************************************************************

--- a/FlashTxx.c
+++ b/FlashTxx.c
@@ -43,32 +43,17 @@ int firmware_buffer_init( uint32_t *buffer_addr, uint32_t *buffer_size )
   #endif
 
   // buffer will begin at first sector ABOVE code and below FLASH_RESERVE
-  // start at bottom of FLASH_RESERVE and work down until large enough non-erased flash found
+  // start at bottom of FLASH_RESERVE and work down until non-erased flash found
   *buffer_addr = FLASH_BASE_ADDR + FLASH_SIZE - FLASH_RESERVE - 4;
-  uint32_t buffer_end = *buffer_addr;
-  do {
-    while (*buffer_addr > 0 && *((uint32_t *)*buffer_addr) == 0xFFFFFFFF)
-      *buffer_addr -= 4;
-    if (buffer_end - *buffer_addr > FLASH_SECTOR_SIZE) {
-      buffer_end += 4;   // address behind non-erased flash
-      *buffer_addr += 4; // first address above code
-      break;
-    }
-    else {
-      // skip non-erased flash memory:
-      while (*buffer_addr > 0 && *((uint32_t *)*buffer_addr) != 0xFFFFFFFF)
-	*buffer_addr -= 4;
-      buffer_end = *buffer_addr;
-    }
-  } while (*buffer_addr > 0);
+  while (*buffer_addr > 0 && *((uint32_t *)*buffer_addr) == 0xFFFFFFFF)
+    *buffer_addr -= 4;
+  *buffer_addr += 4; // first address above code
 
   // increase buffer_addr to next sector boundary (if not on a sector boundary)
   if ((*buffer_addr % FLASH_SECTOR_SIZE) > 0)
     *buffer_addr += FLASH_SECTOR_SIZE - (*buffer_addr % FLASH_SECTOR_SIZE);
-  // decrease buffer_end to previous sector boundary:
-  buffer_end = (buffer_end/FLASH_SECTOR_SIZE)*FLASH_SECTOR_SIZE;
-  *buffer_size = buffer_end - *buffer_addr;
-  if (*buffer_size >= FLASH_SECTOR_SIZE)
+  *buffer_size = FLASH_BASE_ADDR - *buffer_addr + FLASH_SIZE - FLASH_RESERVE;
+  if (*buffer_size > 0)
     return( FLASH_BUFFER_TYPE );
   
   return( NO_BUFFER_TYPE );

--- a/FlashTxx.h
+++ b/FlashTxx.h
@@ -63,6 +63,7 @@
   #define FLASH_SECTOR_SIZE	(0x1000)		// 4KB sector size
   #define FLASH_WRITE_SIZE	(4)			// 4-byte/32-bit writes    
   #define FLASH_RESERVE		(4*FLASH_SECTOR_SIZE)	// reserve top of flash 
+  // #define FLASH_RESERVE	(64*FLASH_SECTOR_SIZE)	// uncomment if you use EEPROM
   #define FLASH_BASE_ADDR	(0x60000000)		// code starts here
 #elif defined(__IMXRT1062__) && defined(ARDUINO_TEENSY_MICROMOD)
   #define FLASH_ID		"fw_teensyMM"		// target ID (in code)


### PR DESCRIPTION
I am using FlasherX for quite a while without problems. However, recently I started to use EEPROM on Teensy 4.1. Since then flashing a new hex file did not work anymore. I now figured out that the problem is in firmware_buffer_init(). The range of free flash memory it returned was simply too small - in fact it was zero after the function adjusted it to FLASH_SECTOR_SIZE. After looking into other regions of flash memory I figured out that there is a much larger range of non-erased memory further down. So, all firmware_buffer_init() needs to do is to look further down until it finds a region that is large enough (I am modest and just require it to be at least one FLASH_SECTOR_SIZE). This is what I have implemented in this pull request and so far this works nicely.